### PR TITLE
fix: upgrade octokit to fix 'TypeError: Octokit is not a constructor'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,45 +4,123 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@octokit/endpoint": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-3.1.3.tgz",
-      "integrity": "sha512-vAWzeoj9Lzpl3V3YkWKhGzmDUoMfKpyxJhpq74/ohMvmLXDoEuAGnApy/7TRi3OmnjyX2Lr+e9UGGAD0919ohA==",
+    "@octokit/auth-token": {
+      "version": "2.4.4",
+      "resolved": "https://globaldevtools.bbva.com:443/artifactory/api/npm/npm-repo/@octokit/auth-token/-/auth-token-2.4.4.tgz",
+      "integrity": "sha1-7jHGmwHQN4wS/T/+QGAw89lNO1Y=",
       "requires": {
-        "deepmerge": "3.2.0",
-        "is-plain-object": "^2.0.4",
-        "universal-user-agent": "^2.0.1",
-        "url-template": "^2.0.8"
+        "@octokit/types": "^6.0.0"
+      }
+    },
+    "@octokit/core": {
+      "version": "3.2.4",
+      "resolved": "https://globaldevtools.bbva.com:443/artifactory/api/npm/npm-repo/@octokit/core/-/core-3.2.4.tgz",
+      "integrity": "sha1-V5ElYFepYuypcuMYGPAkVIl/0QY=",
+      "requires": {
+        "@octokit/auth-token": "^2.4.4",
+        "@octokit/graphql": "^4.5.8",
+        "@octokit/request": "^5.4.12",
+        "@octokit/types": "^6.0.3",
+        "before-after-hook": "^2.1.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/endpoint": {
+      "version": "6.0.10",
+      "resolved": "https://globaldevtools.bbva.com:443/artifactory/api/npm/npm-repo/@octokit/endpoint/-/endpoint-6.0.10.tgz",
+      "integrity": "sha1-dBzh+i9Pt3zo6+DG6vXOY/Vl+Og=",
+      "requires": {
+        "@octokit/types": "^6.0.0",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/graphql": {
+      "version": "4.5.8",
+      "resolved": "https://globaldevtools.bbva.com:443/artifactory/api/npm/npm-repo/@octokit/graphql/-/graphql-4.5.8.tgz",
+      "integrity": "sha1-1CNzYzwwFdDq/OZKjOGWvhZ/3Zs=",
+      "requires": {
+        "@octokit/request": "^5.3.0",
+        "@octokit/types": "^6.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/openapi-types": {
+      "version": "2.2.0",
+      "resolved": "https://globaldevtools.bbva.com:443/artifactory/api/npm/npm-repo/@octokit/openapi-types/-/openapi-types-2.2.0.tgz",
+      "integrity": "sha1-Ej4EOKC8cYzNrDtaLmmz3QDaqFs="
+    },
+    "@octokit/plugin-paginate-rest": {
+      "version": "2.7.0",
+      "resolved": "https://globaldevtools.bbva.com:443/artifactory/api/npm/npm-repo/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.7.0.tgz",
+      "integrity": "sha1-a7ewQ8JG4GVBGabsTnKhcsnix/M=",
+      "requires": {
+        "@octokit/types": "^6.0.1"
+      }
+    },
+    "@octokit/plugin-request-log": {
+      "version": "1.0.2",
+      "resolved": "https://globaldevtools.bbva.com:443/artifactory/api/npm/npm-repo/@octokit/plugin-request-log/-/plugin-request-log-1.0.2.tgz",
+      "integrity": "sha1-OU1Z7HNM0vEiQx+68FCZhh7OPEQ="
+    },
+    "@octokit/plugin-rest-endpoint-methods": {
+      "version": "4.4.1",
+      "resolved": "https://globaldevtools.bbva.com:443/artifactory/api/npm/npm-repo/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.4.1.tgz",
+      "integrity": "sha1-EFz5MlVDIVXeB4ye/DO9ThTRzWM=",
+      "requires": {
+        "@octokit/types": "^6.1.0",
+        "deprecation": "^2.3.1"
       }
     },
     "@octokit/request": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-2.4.1.tgz",
-      "integrity": "sha512-nN8W24ZXEpJQJoVgMsGZeK9FOzxkc39Xn9ykseUpPpPMNEDFSvqfkCeqqKrjUiXRm72ubGLWG1SOz0aJPcgGww==",
+      "version": "5.4.12",
+      "resolved": "https://globaldevtools.bbva.com:443/artifactory/api/npm/npm-repo/@octokit/request/-/request-5.4.12.tgz",
+      "integrity": "sha1-sEgm+pNGcMVrE1qBRHviwXI6L/w=",
       "requires": {
-        "@octokit/endpoint": "^3.1.1",
-        "deprecation": "^1.0.1",
-        "is-plain-object": "^2.0.4",
-        "node-fetch": "^2.3.0",
+        "@octokit/endpoint": "^6.0.1",
+        "@octokit/request-error": "^2.0.0",
+        "@octokit/types": "^6.0.3",
+        "deprecation": "^2.0.0",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.1",
         "once": "^1.4.0",
-        "universal-user-agent": "^2.0.1"
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/request-error": {
+      "version": "2.0.4",
+      "resolved": "https://globaldevtools.bbva.com:443/artifactory/api/npm/npm-repo/@octokit/request-error/-/request-error-2.0.4.tgz",
+      "integrity": "sha1-B91cBSHS7pdSASdMRyoSeRd0EmI=",
+      "requires": {
+        "@octokit/types": "^6.0.0",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
       }
     },
     "@octokit/rest": {
-      "version": "16.17.0",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.17.0.tgz",
-      "integrity": "sha512-1RB7e4ptR/M+1Ik3Qn84pbppbSadBaCtpgFqgqsXn6s4ZVE6hqW9SOm6UW5yd3KT7ObVfdYUkhMlgR937oKyDw==",
+      "version": "18.0.12",
+      "resolved": "https://globaldevtools.bbva.com:443/artifactory/api/npm/npm-repo/@octokit/rest/-/rest-18.0.12.tgz",
+      "integrity": "sha1-J4vUE1jFbYfCAeeH6K3AysEyUDo=",
       "requires": {
-        "@octokit/request": "2.4.1",
-        "before-after-hook": "^1.4.0",
-        "btoa-lite": "^1.0.0",
-        "lodash.get": "^4.4.2",
-        "lodash.set": "^4.3.2",
-        "lodash.uniq": "^4.5.0",
-        "octokit-pagination-methods": "^1.1.0",
-        "universal-user-agent": "^2.0.0",
-        "url-template": "^2.0.8"
+        "@octokit/core": "^3.2.3",
+        "@octokit/plugin-paginate-rest": "^2.6.2",
+        "@octokit/plugin-request-log": "^1.0.2",
+        "@octokit/plugin-rest-endpoint-methods": "4.4.1"
       }
+    },
+    "@octokit/types": {
+      "version": "6.2.1",
+      "resolved": "https://globaldevtools.bbva.com:443/artifactory/api/npm/npm-repo/@octokit/types/-/types-6.2.1.tgz",
+      "integrity": "sha1-f4gf5ER1qxgld2pKWcoa4ILtEEM=",
+      "requires": {
+        "@octokit/openapi-types": "^2.2.0",
+        "@types/node": ">= 8"
+      }
+    },
+    "@types/node": {
+      "version": "14.14.20",
+      "resolved": "https://globaldevtools.bbva.com:443/artifactory/api/npm/npm-repo/@types/node/-/node-14.14.20.tgz",
+      "integrity": "sha1-95dIY+3SHR+KSUpz6OKzZYYVw0A="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -50,14 +128,9 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "before-after-hook": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.4.0.tgz",
-      "integrity": "sha512-l5r9ir56nda3qu14nAXIlyq1MmUSs0meCIaFAh8HwkFwP1F8eToOuS3ah2VAHHcY04jaYD7FpJC5JTXHYRbkzg=="
-    },
-    "btoa-lite": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
-      "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc="
+      "version": "2.1.0",
+      "resolved": "https://globaldevtools.bbva.com:443/artifactory/api/npm/npm-repo/before-after-hook/-/before-after-hook-2.1.0.tgz",
+      "integrity": "sha1-tsA0h/ROJCAN0wyl5qGXnF0vtjU="
     },
     "combined-stream": {
       "version": "1.0.7",
@@ -77,18 +150,6 @@
       "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
       "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
     },
-    "cross-spawn": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-      "requires": {
-        "nice-try": "^1.0.4",
-        "path-key": "^2.0.1",
-        "semver": "^5.5.0",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
-      }
-    },
     "debug": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -97,39 +158,20 @@
         "ms": "^2.1.1"
       }
     },
-    "deepmerge": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.2.0.tgz",
-      "integrity": "sha512-6+LuZGU7QCNUnAJyX8cIrlzoEgggTM6B7mm+znKOX4t5ltluT9KLjN6g61ECMS0LTsLW7yDpNoxhix5FZcrIow=="
-    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "deprecation": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-1.0.1.tgz",
-      "integrity": "sha512-ccVHpE72+tcIKaGMql33x5MAjKQIZrk+3x2GbJ7TeraUCZWHoT+KSZpoC+JQFsUBlSTXUrBaGiF0j6zVTepPLg=="
+      "version": "2.3.1",
+      "resolved": "https://globaldevtools.bbva.com:443/artifactory/api/npm/npm-repo/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha1-Y2jL20Cr8zc7UlrIfkomDDpwCRk="
     },
     "eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
-    },
-    "execa": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
-      "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
-      "requires": {
-        "cross-spawn": "^6.0.0",
-        "get-stream": "^3.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
-      }
     },
     "form-data": {
       "version": "2.3.3",
@@ -146,58 +188,15 @@
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
       "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg=="
     },
-    "get-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
-    },
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "is-plain-object": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "requires": {
-        "isobject": "^3.0.1"
-      }
-    },
-    "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-    },
-    "isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
-    },
-    "isobject": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-    },
-    "lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
-    },
-    "lodash.set": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
-    },
-    "lodash.uniq": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
-    },
-    "macos-release": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.0.0.tgz",
-      "integrity": "sha512-iCM3ZGeqIzlrH7KxYK+fphlJpCCczyHXc+HhRVbEu9uNTCrzYJjvvtefzeKTCVHd5AP/aD/fzC80JZ4ZP+dQ/A=="
+      "version": "5.0.0",
+      "resolved": "https://globaldevtools.bbva.com:443/artifactory/api/npm/npm-repo/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha1-RCf1CrNCnpAl6n1S6QQ6nvQVk0Q="
     },
     "methods": {
       "version": "1.1.2",
@@ -227,44 +226,17 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
-    "nice-try": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
-    },
     "node-fetch": {
       "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
-    },
-    "npm-run-path": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-      "requires": {
-        "path-key": "^2.0.0"
-      }
-    },
-    "octokit-pagination-methods": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz",
-      "integrity": "sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ=="
+      "resolved": "https://globaldevtools.bbva.com:443/artifactory/api/npm/npm-repo/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha1-BFvTI2Mfdu0uK1VXM5RBa2OaAFI="
     },
     "once": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "resolved": "https://globaldevtools.bbva.com:443/artifactory/api/npm/npm-repo/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
         "wrappy": "1"
-      }
-    },
-    "os-name": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/os-name/-/os-name-3.0.0.tgz",
-      "integrity": "sha512-7c74tib2FsdFbQ3W+qj8Tyd1R3Z6tuVRNNxXjJcZ4NgjIEQU9N/prVMqcW29XZPXGACqaXN3jq58/6hoaoXH6g==",
-      "requires": {
-        "macos-release": "^2.0.0",
-        "windows-release": "^3.1.0"
       }
     },
     "p-finally": {
@@ -289,11 +261,6 @@
         "p-finally": "^1.0.0"
       }
     },
-    "path-key": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
-    },
     "qs": {
       "version": "6.6.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.6.0.tgz",
@@ -314,29 +281,6 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
-    "semver": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
-    },
-    "shebang-command": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "requires": {
-        "shebang-regex": "^1.0.0"
-      }
-    },
-    "shebang-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
-    },
-    "signal-exit": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
-    },
     "string_decoder": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
@@ -344,11 +288,6 @@
       "requires": {
         "safe-buffer": "~5.1.0"
       }
-    },
-    "strip-eof": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "superagent": {
       "version": "4.1.0",
@@ -367,42 +306,18 @@
       }
     },
     "universal-user-agent": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-2.0.3.tgz",
-      "integrity": "sha512-eRHEHhChCBHrZsA4WEhdgiOKgdvgrMIHwnwnqD0r5C6AO8kwKcG7qSku3iXdhvHL3YvsS9ZkSGN8h/hIpoFC8g==",
-      "requires": {
-        "os-name": "^3.0.0"
-      }
-    },
-    "url-template": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
-      "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE="
+      "version": "6.0.0",
+      "resolved": "https://globaldevtools.bbva.com:443/artifactory/api/npm/npm-repo/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+      "integrity": "sha1-M4H4UDslHA2c0hvB3pOeyd9UgO4="
     },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
-    "which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "requires": {
-        "isexe": "^2.0.0"
-      }
-    },
-    "windows-release": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.1.0.tgz",
-      "integrity": "sha512-hBb7m7acFgQPQc222uEQTmdcGLeBmQLNLFIh0rDk3CwFOBrfjefLzEfEfmpMq8Af/n/GnFf3eYf203FY1PmudA==",
-      "requires": {
-        "execa": "^0.10.0"
-      }
-    },
     "wrappy": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "https://globaldevtools.bbva.com:443/artifactory/api/npm/npm-repo/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     }
   }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/jaedle/mirror-to-gitea#readme",
   "dependencies": {
-    "@octokit/rest": "^16.2.0",
+    "@octokit/rest": "^18.0.12",
     "p-queue": "^6.6.2",
     "superagent": "^4.0.0"
   }


### PR DESCRIPTION
I was getting this error while using the docker image:

```
code_mirror-github-user.1.jxsr00x4pzkf@rlpvirt06    | (node:7) UnhandledPromiseRejectionWarning: TypeError: Octokit is not a constructor
code_mirror-github-user.1.jxsr00x4pzkf@rlpvirt06    |     at getGithubRepositories (/app/src/index.js:7:19)
code_mirror-github-user.1.jxsr00x4pzkf@rlpvirt06    |     at main (/app/src/index.js:87:36)
code_mirror-github-user.1.jxsr00x4pzkf@rlpvirt06    |     at Object.<anonymous> (/app/src/index.js:104:1)
code_mirror-github-user.1.jxsr00x4pzkf@rlpvirt06    |     at Module._compile (internal/modules/cjs/loader.js:1063:30)
code_mirror-github-user.1.jxsr00x4pzkf@rlpvirt06    |     at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
code_mirror-github-user.1.jxsr00x4pzkf@rlpvirt06    |     at Module.load (internal/modules/cjs/loader.js:928:32)
code_mirror-github-user.1.jxsr00x4pzkf@rlpvirt06    |     at Function.Module._load (internal/modules/cjs/loader.js:769:14)
code_mirror-github-user.1.jxsr00x4pzkf@rlpvirt06    |     at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:72:12)
code_mirror-github-user.1.jxsr00x4pzkf@rlpvirt06    |     at internal/main/run_main_module.js:17:47
code_mirror-github-user.1.jxsr00x4pzkf@rlpvirt06    | (Use `node --trace-warnings ...` to show where the warning was created)
```

I upgraded Octokit to the latest release and now it is working fine for me.