### PR TITLE
Allow skipping forks (and a dry-run bonus)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ services:
           # - GITHUB_TOKEN=please-exchange-with-token # Optional, set to mirror private repos
           # - MIRROR_PRIVATE_REPOSITORIES=true # Optional, set to mirror private repos
           # - DELAY=3600 # Optional, set to change the delay between checks (in seconds)
+          # - SKIP_FORKS=true # Optional, set to skip forks
           # - DRY_RUN=true # Optional, set to only log what would be done
         container_name: mirror-to-gitea
 ```
@@ -98,7 +99,8 @@ In your Docker Compose file, replace `jaedle/mirror-to-gitea:latest` with `build
 
 ### Optional
 - `GITHUB_TOKEN`: [GitHub personal access token](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token). **Attention: if this is set, the token will be transmitted to your specified Gitea instance!**
-- `MIRROR_PRIVATE_REPOSITORIES`: If set to `true`, your private GitHub repositories will also be mirrored to gitea. The `GITHUB_TOKEN` parameter must be set for this to work.
+- `MIRROR_PRIVATE_REPOSITORIES`: If set to `true` or `1`, your private GitHub repositories will also be mirrored to gitea. The `GITHUB_TOKEN` parameter must be set for this to work.
+- `SKIP_FORKS`: If set to `true` or `1`, forks will NOT be mirrored.
 - `DELAY`: How often to check for new repositories in seconds. Default is 3600 (1 hour).
 - `DRY_RUN`: If set to `true` or `1`, the script will only log what would be done, but not actually create any mirror.
 

--- a/README.md
+++ b/README.md
@@ -53,9 +53,10 @@ services:
           - GITHUB_USERNAME=github-user
           - GITEA_URL=https://your-gitea.url
           - GITEA_TOKEN=please-exchange-with-token
-          #- GITHUB_TOKEN=please-exchange-with-token # Optional, set to mirror private repos
-          #- MIRROR_PRIVATE_REPOSITORIES=true # Optional, set to mirror private repos
+          # - GITHUB_TOKEN=please-exchange-with-token # Optional, set to mirror private repos
+          # - MIRROR_PRIVATE_REPOSITORIES=true # Optional, set to mirror private repos
           # - DELAY=3600 # Optional, set to change the delay between checks (in seconds)
+          # - DRY_RUN=true # Optional, set to only log what would be done
         container_name: mirror-to-gitea
 ```
 ## Building from Source
@@ -99,6 +100,7 @@ In your Docker Compose file, replace `jaedle/mirror-to-gitea:latest` with `build
 - `GITHUB_TOKEN`: [GitHub personal access token](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token). **Attention: if this is set, the token will be transmitted to your specified Gitea instance!**
 - `MIRROR_PRIVATE_REPOSITORIES`: If set to `true`, your private GitHub repositories will also be mirrored to gitea. The `GITHUB_TOKEN` parameter must be set for this to work.
 - `DELAY`: How often to check for new repositories in seconds. Default is 3600 (1 hour).
+- `DRY_RUN`: If set to `true` or `1`, the script will only log what would be done, but not actually create any mirror.
 
 ## Things to do
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ version: "3.3"
 services:
     mirror-to-gitea:
         image: jaedle/mirror-to-gitea:latest
-        restart: always
+        restart: unless-stopped
         environment:
           - GITHUB_USERNAME=github-user
           - GITEA_URL=https://your-gitea.url

--- a/src/index.js
+++ b/src/index.js
@@ -115,8 +115,8 @@ async function main() {
     return;
   }
 
-  const mirrorPrivateRepositories = process.env.MIRROR_PRIVATE_REPOSITORIES;
-  if(mirrorPrivateRepositories === 'true' && !githubToken){
+  const mirrorPrivateRepositories = ['1', 'true'].includes(process.env.MIRROR_PRIVATE_REPOSITORIES)
+  if(mirrorPrivateRepositories && !githubToken){
     console.error('MIRROR_PRIVATE_REPOSITORIES was set to true but no GITHUB_TOKEN was specified, please specify! Exiting..')
     return;
   }

--- a/src/index.js
+++ b/src/index.js
@@ -130,6 +130,16 @@ async function main() {
 
   const dryRun = ['1', 'true'].includes(process.env.DRY_RUN);
 
+  console.log("Starting with the following configuration:")
+  console.log(` - GITHUB_USERNAME: ${githubUsername}`);
+  console.log(` - GITHUB_TOKEN: ${githubToken ? '****' : ''}`);
+  console.log(` - GITEA_URL: ${giteaUrl}`);
+  console.log(` - GITEA_TOKEN: ${giteaToken ? '****' : ''}`);
+  console.log(` - MIRROR_PRIVATE_REPOSITORIES: ${mirrorPrivateRepositories}`);
+  console.log(` - SKIP_FORKS: ${!mirrorForks}`);
+  console.log(` - DRY_RUN: ${dryRun}`);
+
+
   const githubRepositories = await getGithubRepositories(githubUsername, githubToken, mirrorPrivateRepositories, mirrorForks);
   console.log(`Found ${githubRepositories.length} repositories on github`);
 


### PR DESCRIPTION
This PR brings the following changes:

* Mainly, by setting the `SKIP_FORKS` env var, forks will not be mirrored, regardless of the other configurations.
* A new option `DRY_RUN` is also introduced. When set, the mirror creation action is skipped but logged. This makes it easier to check the setup before anything is written to Gitea.
* All existing and new environment flags can be enabled by setting them to `true` or `1`
* The current settings are logged in every run, but tokens are masked so they are not revealed in logs.
* Internal: All flags are parsed to booleans early
* Strong suggestion: use `unless-stopped` instead of `always` for the restart policy in the docker-compose example.

Closes: #16 