### PR TITLE
fix: org mirroring when private repo enabled

### DIFF
--- a/src/get-github-repositories.mjs
+++ b/src/get-github-repositories.mjs
@@ -176,6 +176,10 @@ async function fetchOrganizationRepositories(octokit, includeOrgs = [], excludeO
 				});
 				console.log(`Found ${orgRepos.length} public repositories for org: ${orgName}`);
 
+				if (!options.privateRepositories) {
+					orgRepos = orgRepos.filter(repo => !repo.private);
+				}
+
 				// Add organization context to each repository if preserveOrgStructure is enabled
 				if (preserveOrgStructure) {
 					orgRepos = orgRepos.map(repo => ({

--- a/src/get-github-repositories.mjs
+++ b/src/get-github-repositories.mjs
@@ -1,6 +1,6 @@
 async function getRepositories(octokit, mirrorOptions) {
 	let repositories = [];
-	
+
 	// Check if we're mirroring a single repo
 	if (mirrorOptions.singleRepo) {
 		const singleRepo = await fetchSingleRepository(octokit, mirrorOptions.singleRepo);
@@ -16,31 +16,31 @@ async function getRepositories(octokit, mirrorOptions) {
 		const privateRepos = mirrorOptions.privateRepositories
 			? await fetchPrivateRepositories(octokit)
 			: [];
-		
+
 		// Fetch starred repos if the option is enabled
 		const starredRepos = mirrorOptions.mirrorStarred
-			? await fetchStarredRepositories(octokit, { 
-				username: mirrorOptions.useSpecificUser ? mirrorOptions.username : undefined 
+			? await fetchStarredRepositories(octokit, {
+				username: mirrorOptions.useSpecificUser ? mirrorOptions.username : undefined
 			})
 			: [];
-		
+
 		// Fetch organization repos if the option is enabled
 		const orgRepos = mirrorOptions.mirrorOrganizations
 			? await fetchOrganizationRepositories(
-				octokit, 
-				mirrorOptions.includeOrgs, 
+				octokit,
+				mirrorOptions.includeOrgs,
 				mirrorOptions.excludeOrgs,
 				mirrorOptions.preserveOrgStructure,
-				{ 
+				{
 					username: mirrorOptions.useSpecificUser ? mirrorOptions.username : undefined,
 					privateRepositories: mirrorOptions.privateRepositories
 				}
 			)
 			: [];
-		
+
 		// Combine all repositories and filter duplicates
 		repositories = filterDuplicates([
-			...publicRepositories, 
+			...publicRepositories,
 			...privateRepos,
 			...starredRepos,
 			...orgRepos
@@ -60,20 +60,20 @@ async function fetchSingleRepository(octokit, repoUrl) {
 		if (repoPath.endsWith('.git')) {
 			repoPath = repoPath.slice(0, -4);
 		}
-		
+
 		// Split into owner and repo
 		const [owner, repo] = repoPath.split('/');
 		if (!owner || !repo) {
 			console.error(`Invalid repository URL format: ${repoUrl}`);
 			return null;
 		}
-		
+
 		// Fetch the repository details
 		const response = await octokit.rest.repos.get({
 			owner,
 			repo
 		});
-		
+
 		return {
 			name: response.data.name,
 			url: response.data.clone_url,
@@ -114,20 +114,20 @@ async function fetchStarredRepositories(octokit, options = {}) {
 					'X-GitHub-Api-Version': '2022-11-28'
 				}
 			})
-			.then(repos => toRepositoryList(repos.map(repo => ({...repo, starred: true}))));
+			.then(repos => toRepositoryList(repos.map(repo => ({ ...repo, starred: true }))));
 	}
-	
+
 	// Default: Get starred repos for the authenticated user (what was previously used)
 	return octokit
 		.paginate("GET /user/starred")
-		.then(repos => toRepositoryList(repos.map(repo => ({...repo, starred: true}))));
+		.then(repos => toRepositoryList(repos.map(repo => ({ ...repo, starred: true }))));
 }
 
 async function fetchOrganizationRepositories(octokit, includeOrgs = [], excludeOrgs = [], preserveOrgStructure = false, options = {}) {
 	try {
 		// Get all organizations the user belongs to
 		let allOrgs;
-		
+
 		// If a specific username is provided, use the user-specific endpoint
 		if (options.username) {
 			allOrgs = await octokit.paginate("GET /users/{username}/orgs", {
@@ -140,60 +140,42 @@ async function fetchOrganizationRepositories(octokit, includeOrgs = [], excludeO
 			// Default: Get organizations for the authenticated user (what was previously used)
 			allOrgs = await octokit.paginate("GET /user/orgs");
 		}
-		
+
 		// Filter organizations based on include/exclude lists
 		let orgsToProcess = allOrgs;
-		
+
 		if (includeOrgs.length > 0) {
 			// Only include specific organizations
-			orgsToProcess = orgsToProcess.filter(org => 
+			orgsToProcess = orgsToProcess.filter(org =>
 				includeOrgs.includes(org.login)
 			);
 		}
-		
+
 		if (excludeOrgs.length > 0) {
 			// Exclude specific organizations
-			orgsToProcess = orgsToProcess.filter(org => 
+			orgsToProcess = orgsToProcess.filter(org =>
 				!excludeOrgs.includes(org.login)
 			);
 		}
-		
+
 		console.log(`Processing repositories from ${orgsToProcess.length} organizations`);
-		
+
 		// Determine if we need to fetch private repositories
 		const privateRepoAccess = options.privateRepositories && octokit.auth;
 		const allOrgRepos = [];
-		
+
 		// Process each organization
 		for (const org of orgsToProcess) {
 			const orgName = org.login;
 			console.log(`Fetching repositories for organization: ${orgName}`);
-			
+
 			try {
-				let orgRepos = [];
-				
-				// Use search API for organizations when private repositories are requested
-				// This is based on the GitHub community discussion recommendation
-				if (privateRepoAccess) {
-					console.log(`Using search API to fetch both public and private repositories for org: ${orgName}`);
-					// Query for both public and private repositories in the organization
-					const searchQuery = `org:${orgName}`;
-					
-					const searchResults = await octokit.paginate("GET /search/repositories", {
-						q: searchQuery,
-						per_page: 100
-					});
-					
-					orgRepos = searchResults.flatMap(result => result || []);
-					console.log(`Found ${orgRepos.length} repositories (public and private) for org: ${orgName}`);
-				} else {
-					// Use standard API for public repositories only
-					orgRepos = await octokit.paginate("GET /orgs/{org}/repos", { 
-						org: orgName 
-					});
-					console.log(`Found ${orgRepos.length} public repositories for org: ${orgName}`);
-				}
-				
+				const orgRepos = await octokit.paginate("GET /orgs/{org}/repos", {
+					org: orgName,
+					per_page: 100
+				});
+				console.log(`Found ${orgRepos.length} public repositories for org: ${orgName}`);
+
 				// Add organization context to each repository if preserveOrgStructure is enabled
 				if (preserveOrgStructure) {
 					orgRepos = orgRepos.map(repo => ({
@@ -201,13 +183,13 @@ async function fetchOrganizationRepositories(octokit, includeOrgs = [], excludeO
 						organization: orgName
 					}));
 				}
-				
+
 				allOrgRepos.push(...orgRepos);
 			} catch (orgError) {
 				console.error(`Error fetching repositories for org ${orgName}:`, orgError.message);
 			}
 		}
-		
+
 		// Convert to repository list format
 		return toRepositoryList(allOrgRepos, preserveOrgStructure);
 	} catch (error) {
@@ -223,14 +205,14 @@ function withoutForks(repositories) {
 function filterDuplicates(repositories) {
 	const unique = [];
 	const seen = new Set();
-	
+
 	for (const repo of repositories) {
 		if (!seen.has(repo.url)) {
 			seen.add(repo.url);
 			unique.push(repo);
 		}
 	}
-	
+
 	return unique;
 }
 
@@ -245,17 +227,17 @@ function toRepositoryList(repositories, preserveOrgStructure = false) {
 			full_name: repository.full_name,
 			has_issues: repository.has_issues,
 		};
-		
+
 		// Add organization context if it exists and preserveOrgStructure is enabled
 		if (preserveOrgStructure && repository.organization) {
 			repoInfo.organization = repository.organization;
 		}
-		
+
 		// Preserve starred status if present
 		if (repository.starred) {
 			repoInfo.starred = true;
 		}
-		
+
 		return repoInfo;
 	});
 }

--- a/src/get-github-repositories.mjs
+++ b/src/get-github-repositories.mjs
@@ -170,7 +170,7 @@ async function fetchOrganizationRepositories(octokit, includeOrgs = [], excludeO
 			console.log(`Fetching repositories for organization: ${orgName}`);
 
 			try {
-				const orgRepos = await octokit.paginate("GET /orgs/{org}/repos", {
+				let orgRepos = await octokit.paginate("GET /orgs/{org}/repos", {
 					org: orgName,
 					per_page: 100
 				});

--- a/src/get-github-repositories.mjs
+++ b/src/get-github-repositories.mjs
@@ -160,8 +160,6 @@ async function fetchOrganizationRepositories(octokit, includeOrgs = [], excludeO
 
 		console.log(`Processing repositories from ${orgsToProcess.length} organizations`);
 
-		// Determine if we need to fetch private repositories
-		const privateRepoAccess = options.privateRepositories && octokit.auth;
 		const allOrgRepos = [];
 
 		// Process each organization
@@ -172,13 +170,10 @@ async function fetchOrganizationRepositories(octokit, includeOrgs = [], excludeO
 			try {
 				let orgRepos = await octokit.paginate("GET /orgs/{org}/repos", {
 					org: orgName,
+					type: options.privateRepositories ? 'all' : 'public',
 					per_page: 100
 				});
 				console.log(`Found ${orgRepos.length} public repositories for org: ${orgName}`);
-
-				if (!options.privateRepositories) {
-					orgRepos = orgRepos.filter(repo => !repo.private);
-				}
 
 				// Add organization context to each repository if preserveOrgStructure is enabled
 				if (preserveOrgStructure) {

--- a/src/get-github-repositories.mjs
+++ b/src/get-github-repositories.mjs
@@ -184,7 +184,6 @@ async function fetchOrganizationRepositories(octokit, includeOrgs = [], excludeO
 						per_page: 100
 					});
 					
-					// Search API returns repositories in the 'items' array
 					orgRepos = searchResults.flatMap(result => result || []);
 					console.log(`Found ${orgRepos.length} repositories (public and private) for org: ${orgName}`);
 				} else {

--- a/src/get-github-repositories.mjs
+++ b/src/get-github-repositories.mjs
@@ -185,7 +185,7 @@ async function fetchOrganizationRepositories(octokit, includeOrgs = [], excludeO
 					});
 					
 					// Search API returns repositories in the 'items' array
-					orgRepos = searchResults.flatMap(result => result.items || []);
+					orgRepos = searchResults.flatMap(result => result || []);
 					console.log(`Found ${orgRepos.length} repositories (public and private) for org: ${orgName}`);
 				} else {
 					// Use standard API for public repositories only


### PR DESCRIPTION
`.paginate(...)` return a flat array

Also I tested this locally, there is also no need to use search API now, the standard API can include private repositories if auth is given, which is also documented.